### PR TITLE
Fixed scope for using custom World constructor

### DIFF
--- a/src/lib/qcumber.coffee
+++ b/src/lib/qcumber.coffee
@@ -5,7 +5,7 @@ module.exports = (steps)->
 	_defineStep = steps.defineStep
 	qStep = (regex, cb)->
 		_defineStep.call steps, regex, (args..., done)->
-			Q.when(cb.apply(steps, args))
+			Q.when(cb.apply(@, args))
 			.then(->done())
 			.catch(done)
 

--- a/src/lib/qcumber.coffee
+++ b/src/lib/qcumber.coffee
@@ -7,6 +7,6 @@ module.exports = (steps)->
 		_defineStep.call steps, regex, (args..., done)->
 			Q.when(cb.apply(@, args))
 			.then(->done())
-			.catch(done)
+			.catch((e)->done.fail(e))
 
 	steps.Given = steps.When = steps.Then = steps.defineStep = qStep


### PR DESCRIPTION
Using custom constructor like this

```
this.World = require('../support/world.js').World;
```

require step definition callback fired in world's scope. Passing through original context is good idea anyway. 

Im not into coffee script, forgive me if it should be done differently.
