### PR TITLE
Fixed scope for using custom World constructor

### DIFF
--- a/src/features/steps/steps.js
+++ b/src/features/steps/steps.js
@@ -1,9 +1,9 @@
 module.exports = function(){
     require('../../lib/qcumber')(this);
 
+    this.World = require('../support/world').World;
+
     this.When(/action requiring correct scope/, function(){
-        return new Promise(function(resolve, reject){
-            resolve();
-        });
+        return this.doSomeAction();
     });
 };

--- a/src/features/support/world.js
+++ b/src/features/support/world.js
@@ -1,0 +1,11 @@
+var Q = require('q');
+
+exports.World = function (callback) {
+    this.doSomeAction = function () {
+        return new Q.Promise(function(resolve, reject){
+            resolve();
+        });
+    };
+
+    callback();
+};

--- a/src/lib/qcumber.coffee
+++ b/src/lib/qcumber.coffee
@@ -5,7 +5,7 @@ module.exports = (steps)->
 	_defineStep = steps.defineStep
 	qStep = (regex, cb)->
 		_defineStep.call steps, regex, (args..., done)->
-			Q.when(cb.apply(steps, args))
+			Q.when(cb.apply(@, args))
 			.then(->done())
 			.catch(done)
 


### PR DESCRIPTION
Using custom constructor like this

```
this.World = require('../support/world.js').World;
```

require step definition callback fired in world's scope. Passing through original context is good idea anyway.
